### PR TITLE
Add style to wl1's enable button

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -308,6 +308,9 @@ input[type="button"][disabled]:active {
 #b_wl0_enable {
   margin-right: 4px;
 }
+#b_wl1_enable {
+  margin-right: 4px;
+}
 #afu-upgrade-button {
   height: auto !important;
   background-color: #27ae60;


### PR DESCRIPTION
Thanks for the awesome theme! This just fixes a slight visual discrepancy when you have a 2nd WLAN (5Ghz) on the status page.

I didn't touch `custom.min.css` because I'm not sure which minification process you use, but if you want me to just add it in directly I can do that too.